### PR TITLE
Generate `contract.CallArguments` for each function call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jeanschmitt/tzgen
+module github.com/AugustDev/tzgen
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AugustDev/tzgen
+module github.com/jeanschmitt/tzgen
 
 go 1.19
 

--- a/internal/generate/contract.go.tmpl
+++ b/internal/generate/contract.go.tmpl
@@ -2,6 +2,10 @@
     {{- range .Params}}{{camel .Name}} {{type .Type}},{{end -}}
 {{- end -}}
 
+{{- define "entryParamsListBatch" -}}
+    {{- range .Params}}{{camel .Name}} []{{type .Type}},{{end -}}
+{{- end -}}
+
 {{- define "originalSignature" -}}
     {{- $nArgs := len .Params -}}
 	{{.Name}}({{range $i, $param := .Params}}{{$param.Name}} {{$param.OriginalType}}{{if lt $i (sub $nArgs 1)}}, {{end}}{{end}})
@@ -150,6 +154,21 @@ func {{$rc}} {{pascal .Name}}(ctx context.Context, opts *rpc.CallOptions, {{temp
 		return nil, err
 	}
 	return {{$r}}.Contract.Call(ctx, &contract.TxArgs{Params: params}, opts)
+}
+
+// {{pascal .Name}} makes a call to the `{{.Name}}` contract entry.
+//
+// {{template "originalSignature" .}}
+func {{$rc}} {{pascal .Name}}Batch(ctx context.Context, opts *rpc.CallOptions, {{template "entryParamsListBatch" .}}) (*rpc.Receipt, error) {
+    var callArgs []contract.CallArguments
+    for i := range meta {
+        params, err := {{$r}}.builder.{{pascal .Name}}({{range .Params}}{{camel .Name}},{{end}})
+        if err != nil {
+            return nil, err
+        }
+        callArgs = append(callArgs, &contract.TxArgs{Params: params})
+	}
+	return {{$r}}.Contract.CallMulti(ctx, callArgs, opts)
 }
 
 // {{pascal .Name}} makes a call to the `{{.Name}}` contract entry.

--- a/internal/generate/contract.go.tmpl
+++ b/internal/generate/contract.go.tmpl
@@ -156,19 +156,15 @@ func {{$rc}} {{pascal .Name}}(ctx context.Context, opts *rpc.CallOptions, {{temp
 	return {{$r}}.Contract.Call(ctx, &contract.TxArgs{Params: params}, opts)
 }
 
-// {{pascal .Name}} makes a call to the `{{.Name}}` contract entry.
+// {{pascal .Name}} generates `{{.Name}}` operation call.
 //
 // {{template "originalSignature" .}}
-func {{$rc}} {{pascal .Name}}Batch(ctx context.Context, opts *rpc.CallOptions, {{template "entryParamsListBatch" .}}) (*rpc.Receipt, error) {
-    var callArgs []contract.CallArguments
-    for i := range meta {
-        params, err := {{$r}}.builder.{{pascal .Name}}({{range .Params}}{{camel .Name}},{{end}})
-        if err != nil {
-            return nil, err
-        }
-        callArgs = append(callArgs, &contract.TxArgs{Params: params})
+func {{$rc}} {{pascal .Name}}Args({{template "entryParamsList" .}}) (*rpc.Receipt, error) {
+	params, err := {{$r}}.builder.{{pascal .Name}}({{range .Params}}{{camel .Name}},{{end}})
+	if err != nil {
+		return nil, err
 	}
-	return {{$r}}.Contract.CallMulti(ctx, callArgs, opts)
+	return &contract.TxArgs{Params: params}, nil
 }
 
 // {{pascal .Name}} makes a call to the `{{.Name}}` contract entry.

--- a/internal/generate/contract.go.tmpl
+++ b/internal/generate/contract.go.tmpl
@@ -156,7 +156,7 @@ func {{$rc}} {{pascal .Name}}(ctx context.Context, opts *rpc.CallOptions, {{temp
 	return {{$r}}.Contract.Call(ctx, &contract.TxArgs{Params: params}, opts)
 }
 
-// {{pascal .Name}} generates `{{.Name}}` operation call.
+// {{pascal .Name}} generates `{{.Name}}` operation args.
 //
 // {{template "originalSignature" .}}
 func {{$rc}} {{pascal .Name}}Args({{template "entryParamsList" .}}) (contract.CallArguments, error) {

--- a/internal/generate/contract.go.tmpl
+++ b/internal/generate/contract.go.tmpl
@@ -2,10 +2,6 @@
     {{- range .Params}}{{camel .Name}} {{type .Type}},{{end -}}
 {{- end -}}
 
-{{- define "entryParamsListBatch" -}}
-    {{- range .Params}}{{camel .Name}} []{{type .Type}},{{end -}}
-{{- end -}}
-
 {{- define "originalSignature" -}}
     {{- $nArgs := len .Params -}}
 	{{.Name}}({{range $i, $param := .Params}}{{$param.Name}} {{$param.OriginalType}}{{if lt $i (sub $nArgs 1)}}, {{end}}{{end}})

--- a/internal/generate/contract.go.tmpl
+++ b/internal/generate/contract.go.tmpl
@@ -159,7 +159,7 @@ func {{$rc}} {{pascal .Name}}(ctx context.Context, opts *rpc.CallOptions, {{temp
 // {{pascal .Name}} generates `{{.Name}}` operation call.
 //
 // {{template "originalSignature" .}}
-func {{$rc}} {{pascal .Name}}Args({{template "entryParamsList" .}}) (*rpc.Receipt, error) {
+func {{$rc}} {{pascal .Name}}Args({{template "entryParamsList" .}}) (contract.CallArguments, error) {
 	params, err := {{$r}}.builder.{{pascal .Name}}({{range .Params}}{{camel .Name}},{{end}})
 	if err != nil {
 		return nil, err

--- a/pkg/bind/interface.go
+++ b/pkg/bind/interface.go
@@ -11,6 +11,7 @@ import (
 type Contract interface {
 	Address() tezos.Address
 	Call(ctx context.Context, args contract.CallArguments, opts *rpc.CallOptions) (*rpc.Receipt, error)
+	CallMulti(ctx context.Context, args []contract.CallArguments, opts *rpc.CallOptions) (*rpc.Receipt, error)
 	RunView(ctx context.Context, name string, args micheline.Prim) (micheline.Prim, error)
 }
 


### PR DESCRIPTION
Tezos allows to batch multiple operations into single transaction, however currently this is not possible using `tzgen`. 

With new method `fnArgs` that returns `contract.CallArguments`, one can send multiple operations using single transaction for example

```go
myContract.Contract.CallMulti(ctx, []contract.CallArguments{arg1, arg2}, &opts)
```